### PR TITLE
Support rooted production build phones and Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,4 +19,4 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose -- --skip skip_in_ci

--- a/btsnoop-extcap/Cargo.toml
+++ b/btsnoop-extcap/Cargo.toml
@@ -28,6 +28,7 @@ env_logger = "0.10.0"
 async-trait = "0.1.64"
 thiserror = "1.0.38"
 lazy_static = "1.4.0"
+shlex = "1.1.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/btsnoop-extcap/Cargo.toml
+++ b/btsnoop-extcap/Cargo.toml
@@ -23,7 +23,7 @@ nom-derive = "0.10.0"
 nom = "7.1.3"
 regex = "1.7.1"
 tokio = { version = "1.25.0", features = ["full"] }
-log = { version = "0.4.17", features = ["release_max_level_info"] }
+log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_info"] }
 async-trait = "0.1.64"
 thiserror = "1.0.38"
 lazy_static = "1.4.0"

--- a/btsnoop-extcap/Cargo.toml
+++ b/btsnoop-extcap/Cargo.toml
@@ -34,5 +34,6 @@ log4rs = { version = "1.2.0" }
 
 [dev-dependencies]
 assert_cmd = "2.0.8"
+assert_fs = "1.0.12"
 indoc = "2.0.1"
 predicates = "2.1.5"

--- a/btsnoop-extcap/Cargo.toml
+++ b/btsnoop-extcap/Cargo.toml
@@ -29,6 +29,8 @@ async-trait = "0.1.64"
 thiserror = "1.0.38"
 lazy_static = "1.4.0"
 shlex = "1.1.0"
+which = "4.4.0"
+dirs-next = "2.0.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/btsnoop-extcap/Cargo.toml
+++ b/btsnoop-extcap/Cargo.toml
@@ -23,14 +23,14 @@ nom-derive = "0.10.0"
 nom = "7.1.3"
 regex = "1.7.1"
 tokio = { version = "1.25.0", features = ["full"] }
-log = "0.4.17"
-env_logger = "0.10.0"
+log = { version = "0.4.17", features = ["release_max_level_info"] }
 async-trait = "0.1.64"
 thiserror = "1.0.38"
 lazy_static = "1.4.0"
 shlex = "1.1.0"
 which = "4.4.0"
 dirs-next = "2.0.0"
+log4rs = { version = "1.2.0" }
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/btsnoop-extcap/README.md
+++ b/btsnoop-extcap/README.md
@@ -33,10 +33,17 @@ Detected devices are shown in Wireshark's __Capture__ interface list.
 
 ## Instructions to turn on btsnoop log capturing
 
+#### Option 1
+
+1. In Wireshark, open the toolbar View > Interface Toolbars > Android btsnoop
+2. Select the btsnoop interface in the main Wireshark window
+3. Click "Turn on BT logging" in the toolbar
+
+#### Option 2
+
 1. Enable __Developer options__ on the device.
 2. In the __Developer options__ menu, activate the __Enable Bluetooth HCI snoop log__ toggle.
 3. Restart Bluetooth for logging to take effect.
-4. Run `adb root`
 
 ## Relationship with `androiddump`
 

--- a/btsnoop-extcap/create_debug_extcap.sh
+++ b/btsnoop-extcap/create_debug_extcap.sh
@@ -9,8 +9,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 cat <<EOF > ~/.config/wireshark/extcap/btsnoop-extcap
 #! /usr/bin/env bash
-exec 2>/tmp/btsnoop-extcap.log
 # Use exec to make sure the rust program will get SIGTERM from wireshark when stopping
-RUST_LOG=debug exec $SCRIPT_DIR/../target/debug/btsnoop-extcap "\$@"
+exec $SCRIPT_DIR/../target/debug/btsnoop-extcap "\$@"
 EOF
 chmod +x ~/.config/wireshark/extcap/btsnoop-extcap

--- a/btsnoop-extcap/src/adb.rs
+++ b/btsnoop-extcap/src/adb.rs
@@ -266,9 +266,9 @@ mod adb_assumption_tests {
     use predicates::prelude::predicate;
 
     #[cfg(windows)]
-    const LINE_ENDING: &'static str = "\r\n";
+    const LINE_ENDING: &str = "\r\n";
     #[cfg(not(windows))]
-    const LINE_ENDING: &'static str = "\n";
+    const LINE_ENDING: &str = "\n";
 
     #[test]
     fn adb_exec_out_with_su() {
@@ -279,7 +279,7 @@ mod adb_assumption_tests {
             .arg(r#"su -c "echo -n 'hello\nworld'""#);
         cmd.assert()
             .success()
-            .stdout(predicate::str::diff(format!("hello{LINE_ENDING}world"))
+            .stdout(predicate::str::diff("hello\r\nworld")
         );
     }
 

--- a/btsnoop-extcap/src/adb.rs
+++ b/btsnoop-extcap/src/adb.rs
@@ -8,7 +8,7 @@ use tokio::process::Command;
 
 #[derive(Error, Debug)]
 pub enum AdbRootError {
-    #[error("Root was declined. Check that you are on a userdebug or eng build.")]
+    #[error("Unable to get root access. Make sure your device is rooted or on a userdebug/eng build.")]
     RootDeclined,
 
     #[error(transparent)]
@@ -81,6 +81,7 @@ pub async fn root(adb_path: &str, serial: &str) -> Result<RootShell, AdbRootErro
         .await?
         .stdout;
     debug!("Shell UID={shell_uid:?}");
+    // If only `adb root` will return a different exit code...
     if trim_end(&shell_uid) != b"0" {
         let shell_uid = shell(serial, "su -c id -u")
             .stdout(Stdio::piped())
@@ -89,7 +90,6 @@ pub async fn root(adb_path: &str, serial: &str) -> Result<RootShell, AdbRootErro
             .await?
             .stdout;
         if trim_end(&shell_uid) != b"0" {
-            // If only `adb root` will return a different exit code...
             Err(AdbRootError::RootDeclined)?;
         } else {
             return Ok(RootShell {

--- a/btsnoop-extcap/src/adb.rs
+++ b/btsnoop-extcap/src/adb.rs
@@ -259,9 +259,14 @@ pub fn find_adb(adb_path: Option<String>) -> anyhow::Result<PathBuf> {
     }
 }
 
-/// Tests our assumptions about the behavior of adb.
+/// Tests our assumptions about the behavior of adb. These tests require you to
+/// be connected to a device over adb in order to run. To ignore these tests, use
+///
+/// ```sh
+/// cargo test -- --skip skip_in_ci
+/// ```
 #[cfg(test)]
-mod adb_assumption_tests {
+mod skip_in_ci_adb_assumption_tests {
     use assert_cmd::Command;
     use predicates::prelude::predicate;
 

--- a/btsnoop-extcap/src/main.rs
+++ b/btsnoop-extcap/src/main.rs
@@ -170,7 +170,7 @@ async fn print_packets(
             Err(e) => Err(e)?,
             Ok(shell) => shell,
         };
-        if BtsnoopLogSettings::mode(&root_shell).await? == BtsnoopLogMode::Full {
+        if let Ok(BtsnoopLogMode::Full) = BtsnoopLogSettings::mode(&root_shell).await {
             extcap_control
                 .send(BT_LOGGING_ON_BUTTON.set_enabled(false))
                 .await?;

--- a/btsnoop-extcap/src/main.rs
+++ b/btsnoop-extcap/src/main.rs
@@ -150,7 +150,9 @@ async fn print_packets(
     } else {
         let root_shell = match adb::root(adb_path, serial).await {
             Err(e @ AdbRootError::RootDeclined) => {
-                extcap_control.info_message("Unable to run `adb root`. Make sure your device is on a userdebug or eng build").await?;
+                extcap_control.info_message(
+                    "Unable to get root access. Make sure your device is rooted or on a userdebug/eng build"
+                ).await?;
                 tokio::time::sleep(Duration::from_secs(1)).await;
                 Err(e)?
             }
@@ -255,8 +257,13 @@ async fn main() -> anyhow::Result<()> {
                 async {
                     if let Some(mut reader) = extcap_reader {
                         while let Ok(packet) = reader.read_control_packet().await {
-                            handle_control_packet(adb_path, serial, packet, &mut *extcap_sender.lock().await)
-                                .await?;
+                            handle_control_packet(
+                                adb_path,
+                                serial,
+                                packet,
+                                &mut *extcap_sender.lock().await,
+                            )
+                            .await?;
                         }
                     }
                     debug!("Control packet handling ending");

--- a/btsnoop-extcap/tests/cli.rs
+++ b/btsnoop-extcap/tests/cli.rs
@@ -1,4 +1,5 @@
 use assert_cmd::prelude::*;
+use assert_fs::prelude::PathAssert;
 use indoc::indoc;
 use predicates::prelude::*;
 use std::process::Command;
@@ -26,19 +27,19 @@ fn contains(needle: &[u8]) -> impl Fn(&[u8]) -> bool + '_ {
 
 #[test]
 fn capture() {
+    let tmpfile = assert_fs::NamedTempFile::new("fifo").unwrap();
     let mut cmd = Command::cargo_bin("btsnoop-extcap").unwrap();
     cmd.arg("--extcap-interface")
         .arg("btsnoop-SERIAL")
         .arg("--capture")
         .arg("--fifo")
-        .arg("/dev/stdout")
+        .arg(tmpfile.path())
         .arg("--btsnoop-log-file-path")
         .arg("local:tests/testdata/btsnoop_hci.log")
         .arg("--display-delay")
         .arg("0");
-    cmd.assert()
-        .success()
-        .stdout(predicate::function(contains(b"Pixel 6 Pro")));
+    cmd.assert().success();
+    tmpfile.assert(predicate::function(contains(b"Pixel 6 Pro")).from_file_path());
 }
 
 #[test]


### PR DESCRIPTION
- Fix some windows issues with line endings
- Support rooted phones using `adb shell su -c` when `adb root` doesn't work

Fixes #2 