### PR TITLE
Update extcap installation instructions for Wireshark 4.1

### DIFF
--- a/btsnoop-extcap/Cargo.toml
+++ b/btsnoop-extcap/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["parser-implementations"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-r-extcap = { version = "0.2.0" }
+r-extcap = { version = "0.2.1" }
 btsnoop = { version = "0.2.0", path = "../btsnoop" }
 pcap-file = "2.0.0"
 anyhow = "1.0.68"

--- a/btsnoop-extcap/Cargo.toml
+++ b/btsnoop-extcap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btsnoop-extcap"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Maurice Lam <mauriceprograms@gmail.com>"]
 description = "View Android's btsnoop logs (Bluetooth HCI logs) in Wireshark"

--- a/btsnoop-extcap/README.md
+++ b/btsnoop-extcap/README.md
@@ -14,12 +14,14 @@ $ btsnoop-extcap
 Unknown extcap phase. This is an extcap plugin meant to be used with Wireshark or tshark.
 To install this plugin for use with Wireshark, symlink or copy this executable
 to your Wireshark extcap directory
-    mkdir -p ~/.config/wireshark/extcap/ && \
-    ln -s "~/.cargo/bin/btsnoop-extcap" ~/.config/wireshark/extcap/btsnoop-extcap
 
-# Run the symlink command in the error message
-$ mkdir -p ~/.config/wireshark/extcap/ && \
-  ln -s "~/.cargo/bin/btsnoop-extcap" ~/.config/wireshark/extcap/btsnoop-extcap
+# Run the symlink command in the error message (for Wireshark 4.1 or later)
+$ mkdir -p "$HOME/.local/lib/wireshark/extcap/" && \
+  ln -s "$HOME/.cargo/bin/btsnoop-extcap" "$HOME/.local/lib/wireshark/extcap/btsnoop-extcap"
+
+# or for Wireshark 4.0 or before
+$ mkdir -p "$HOME/.cargo/wireshark/extcap/" && \
+  ln -s "$HOME/.cargo/bin/btsnoop-extcap" "$HOME/.cargo/wireshark/extcap/btsnoop-extcap"
 ```
 
 _Root is required on the selected Android device._

--- a/btsnoop-extcap/create_debug_extcap.sh
+++ b/btsnoop-extcap/create_debug_extcap.sh
@@ -7,6 +7,7 @@ set -ex
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+# NOTE: Change to ~/.local/lib/wireshark/extcap if using Wireshark 4.1 or above
 cat <<EOF > ~/.config/wireshark/extcap/btsnoop-extcap
 #! /usr/bin/env bash
 exec 2>/tmp/btsnoop-extcap.log


### PR DESCRIPTION
Version bump to 0.1.2 for btsnoop-extcap. 