### PR TITLE
Add datalink types for btmon

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ pub enum DatalinkType {
     HciUart = 1002,
     HciBscp = 1003,
     HciSerial = 1004,
+    Monitor = 2001,
+    Simulator = 2002,
 }
 
 /// The file header contains general metadata about the packet file and format of the packets it


### PR DESCRIPTION
btmon currently uses the `Monitor` type when recording, so add here to support btmon-generated logs.

Ref: https://github.com/bluez/bluez/blob/ae9bf50a27922f2f62a465b62800e90f0fba7831/src/shared/btsnoop.h#L20-L21